### PR TITLE
Make API calls use different versions

### DIFF
--- a/modification_gateway.go
+++ b/modification_gateway.go
@@ -15,7 +15,9 @@ type ModificationGateway struct {
 
 // Capture - Perform capture payment in Adyen
 func (a *ModificationGateway) Capture(req *Capture) (*CaptureResponse, error) {
-	resp, err := a.execute(PaymentService, captureType, req)
+	url := a.adyenURL(PaymentService, captureType, PaymentAPIVersion)
+
+	resp, err := a.execute(url, req)
 
 	if err != nil {
 		return nil, err
@@ -26,7 +28,9 @@ func (a *ModificationGateway) Capture(req *Capture) (*CaptureResponse, error) {
 
 // Cancel - Perform cancellation of the authorised transaction
 func (a *ModificationGateway) Cancel(req *Cancel) (*CancelResponse, error) {
-	resp, err := a.execute(PaymentService, cancelType, req)
+	url := a.adyenURL(PaymentService, cancelType, PaymentAPIVersion)
+
+	resp, err := a.execute(url, req)
 
 	if err != nil {
 		return nil, err
@@ -38,7 +42,9 @@ func (a *ModificationGateway) Cancel(req *Cancel) (*CancelResponse, error) {
 // CancelOrRefund - Perform cancellation for not captured transaction
 // otherwise perform refund action
 func (a *ModificationGateway) CancelOrRefund(req *Cancel) (*CancelOrRefundResponse, error) {
-	resp, err := a.execute(PaymentService, cancelOrRefundType, req)
+	url := a.adyenURL(PaymentService, cancelOrRefundType, PaymentAPIVersion)
+
+	resp, err := a.execute(url, req)
 
 	if err != nil {
 		return nil, err
@@ -49,7 +55,9 @@ func (a *ModificationGateway) CancelOrRefund(req *Cancel) (*CancelOrRefundRespon
 
 // Refund - perform refund for already captured request
 func (a *ModificationGateway) Refund(req *Refund) (*RefundResponse, error) {
-	resp, err := a.execute(PaymentService, refundType, req)
+	url := a.adyenURL(PaymentService, refundType, PaymentAPIVersion)
+
+	resp, err := a.execute(url, req)
 
 	if err != nil {
 		return nil, err

--- a/payment3d_gateway.go
+++ b/payment3d_gateway.go
@@ -10,7 +10,9 @@ const authorise3DType = "authorise3d"
 
 // Authorise3D - Perform authorise payment in Adyen
 func (a *PaymentGateway) Authorise3D(req *Authorise3D) (*AuthoriseResponse, error) {
-	resp, err := a.execute(PaymentService, authorise3DType, req)
+	url := a.adyenURL(PaymentService, authorise3DType, PaymentAPIVersion)
+
+	resp, err := a.execute(url, req)
 
 	if err != nil {
 		return nil, err

--- a/payment_gateway.go
+++ b/payment_gateway.go
@@ -32,7 +32,9 @@ const skipHppURL = "skipDetails"
 //}
 // adyen.Recurring{Contract:adyen.RecurringPaymentRecurring} as one of the contracts
 func (a *PaymentGateway) AuthoriseEncrypted(req *AuthoriseEncrypted) (*AuthoriseResponse, error) {
-	resp, err := a.execute(PaymentService, authoriseType, req)
+	url := a.adyenURL(PaymentService, authoriseType, PaymentAPIVersion)
+
+	resp, err := a.execute(url, req)
 
 	if err != nil {
 		return nil, err
@@ -49,7 +51,9 @@ func (a *PaymentGateway) AuthoriseEncrypted(req *AuthoriseEncrypted) (*Authorise
 //
 // Please use AuthoriseEncrypted instead and adyen frontend encryption library
 func (a *PaymentGateway) Authorise(req *Authorise) (*AuthoriseResponse, error) {
-	resp, err := a.execute(PaymentService, authoriseType, req)
+	url := a.adyenURL(PaymentService, authoriseType, PaymentAPIVersion)
+
+	resp, err := a.execute(url, req)
 
 	if err != nil {
 		return nil, err
@@ -69,7 +73,12 @@ func (a *PaymentGateway) DirectoryLookup(req *DirectoryLookupRequest) (*Director
 		return nil, err
 	}
 
-	resp, err := a.executeHpp(directoryLookupURL, req)
+	url := a.createHPPUrl(directoryLookupURL)
+
+	v, _ := query.Values(req)
+	url = url + "?" + v.Encode()
+
+	resp, err := a.executeHpp(url, req)
 
 	if err != nil {
 		return nil, err

--- a/recurring_gateway.go
+++ b/recurring_gateway.go
@@ -5,15 +5,18 @@ type RecurringGateway struct {
 	*Adyen
 }
 
-// listRecurringDetailsType - listRecurringDetails type request, @TODO: move to enums
-const listRecurringDetailsType = "listRecurringDetails"
-
-// disableRecurringType - disable recurring type request, @TODO: move to enums
-const disableRecurringType = "disable"
+const (
+	// listRecurringDetailsType - listRecurringDetails type request, @TODO: move to enums
+	listRecurringDetailsType = "listRecurringDetails"
+	// disableRecurringType - disable recurring type request, @TODO: move to enums
+	disableRecurringType = "disable"
+)
 
 // ListRecurringDetails - Get list of recurring payments in Adyen
 func (a *RecurringGateway) ListRecurringDetails(req *RecurringDetailsRequest) (*RecurringDetailsResult, error) {
-	resp, err := a.execute(RecurringService, listRecurringDetailsType, req)
+	url := a.adyenURL(RecurringService, listRecurringDetailsType, RecurringAPIVersion)
+
+	resp, err := a.execute(url, req)
 
 	if err != nil {
 		return nil, err
@@ -24,7 +27,9 @@ func (a *RecurringGateway) ListRecurringDetails(req *RecurringDetailsRequest) (*
 
 // DisableRecurring - disable customer's saved payment method based on a contract type or/and payment method ID
 func (a *RecurringGateway) DisableRecurring(req *RecurringDisableRequest) (*RecurringDisableResponse, error) {
-	resp, err := a.execute(RecurringService, disableRecurringType, req)
+	url := a.adyenURL(RecurringService, disableRecurringType, RecurringAPIVersion)
+
+	resp, err := a.execute(url, req)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Make API calls use different versions

Closes #34 

- Payment, modification requests are using v30
- Recurring requests should use v25
- make gateways prepare the URL and then be executed by adyen.go