### PR TITLE
ISSUE-63 - Add executeThreeD value to AdditionalData

### DIFF
--- a/boolean.go
+++ b/boolean.go
@@ -22,3 +22,16 @@ func (b *stringBool) UnmarshalJSON(data []byte) (err error) {
 	*b = stringBool(parsed)
 	return
 }
+
+func (b stringBool) MarshalJSON() ([]byte, error) {
+	boolResult := bool(b)
+	var boolString string
+
+	if boolResult {
+		boolString = `"true"`
+	} else {
+		boolString = `"false"`
+	}
+
+	return []byte(boolString), nil
+}

--- a/boolean_test.go
+++ b/boolean_test.go
@@ -9,6 +9,10 @@ type thing struct {
 	Bool stringBool `json:"value"`
 }
 
+type thingWithEmpty struct {
+	Bool *stringBool `json:"value,omitempty"`
+}
+
 func TestStringBool_Unmarshal(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -82,6 +86,74 @@ func TestStringBool_Unmarshal(t *testing.T) {
 
 			if stringBool(c.exp) != th.Bool {
 				t.Fatalf("my exp: %v but got %v", c.exp, th.Bool)
+			}
+		})
+	}
+}
+
+func TestStringBool_Marshal(t *testing.T) {
+	cases := []struct {
+		name     string
+		object   thing
+		expected string
+	}{
+		{
+			name:     "true",
+			object:   thing{Bool: stringBool(true)},
+			expected: `{"value":"true"}`,
+		},
+		{
+			name:     "false",
+			object:   thing{Bool: stringBool(false)},
+			expected: `{"value":"false"}`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res, _ := json.Marshal(c.object)
+			str := string(res)
+
+			if c.expected != str {
+				t.Fatalf("my exp: %v but got %v", c.expected, str)
+			}
+		})
+	}
+}
+
+func TestStringBool_MarshalWithOmitempty(t *testing.T) {
+	valueTrue := stringBool(true)
+	valueFalse := stringBool(false)
+
+	cases := []struct {
+		name     string
+		object   thingWithEmpty
+		expected string
+	}{
+		{
+			name:     "true",
+			object:   thingWithEmpty{Bool: &valueTrue},
+			expected: `{"value":"true"}`,
+		},
+		{
+			name:     "false",
+			object:   thingWithEmpty{Bool: &valueFalse},
+			expected: `{"value":"false"}`,
+		},
+		{
+			name:     "false",
+			object:   thingWithEmpty{},
+			expected: `{}`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res, _ := json.Marshal(c.object)
+			str := string(res)
+
+			if c.expected != str {
+				t.Fatalf("my exp: %v but got %v", c.expected, str)
 			}
 		})
 	}

--- a/payment.go
+++ b/payment.go
@@ -74,9 +74,10 @@ type AuthoriseResponse struct {
 
 // AdditionalData stores encrypted information about customer's credit card
 type AdditionalData struct {
-	Content   string `json:"card.encrypted.json,omitempty"`
-	AliasType string `json:"aliasType,omitempty"`
-	Alias     string `json:"alias,omitempty"`
+	Content       string      `json:"card.encrypted.json,omitempty"`
+	AliasType     string      `json:"aliasType,omitempty"`
+	Alias         string      `json:"alias,omitempty"`
+	ExecuteThreeD *stringBool `json:"executeThreeD,omitempty"`
 }
 
 // BrowserInfo hold information on the user browser

--- a/payment_gateway_test.go
+++ b/payment_gateway_test.go
@@ -1,6 +1,7 @@
 package adyen
 
 import (
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -75,12 +76,18 @@ func TestAuthorise(t *testing.T) {
 		t.Errorf("Response should be succesfull, error - %s", err.Error())
 	}
 
+	responseBytes, err := json.Marshal(response)
+
+	if err != nil {
+		t.Error("Response can't be converted to JSON")
+	}
+
 	if response.PspReference == "" {
-		t.Errorf("Response should contain PSP Reference. Response - %s", response)
+		t.Errorf("Response should contain PSP Reference. Response - %s", string(responseBytes))
 	}
 
 	if response.ResultCode != "Authorised" {
-		t.Errorf("Response resultCode should be Authorised, Response - %s", response)
+		t.Errorf("Response resultCode should be Authorised, Response - %s", string(responseBytes))
 	}
 }
 


### PR DESCRIPTION
Due to Adyen API requirement to have bools as a string representation ("true"/"false"), we need to use `stringBool` type

To enable cases with the value set to "true"/"false" or not specified we need have `Bool *stringBool` definition in structure

Closes #63 