### PR TITLE
Add Golang 1.10 and 1.11 to Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ stages:
   - verification
   - test
 
+go:
+  - 1.11.x
+  - 1.10.x
+  - 1.9.x
+  
 jobs:
   include:
     - stage: verification

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 stages:
   - verification
   - test
-  
+
 jobs:
   include:
     - stage: verification

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,25 +15,30 @@ install:
 stages:
   - verification
   - test
-
-go:
-  - 1.11.x
-  - 1.10.x
-  - 1.9.x
   
 jobs:
   include:
     - stage: verification
       go: 1.9
       script: make verification
-
+   - stage: verification
+      go: 1.10
+      script: make verification
+   - stage: verification
+      go: 1.11
+      script: make verification
     - stage: test
-      go: 1.9
+      go: 1.11
       script:
         - make test
         - gover
         - goveralls -service=travis-ci -coverprofile=gover.coverprofile -repotoken $COVERALLS_TOKEN
-
+    - stage: test
+      go: 1.10
+      script: make test
+    - stage: test
+      go: 1.9
+      script: make test
     - stage: test
       go: 1.8
       script: make test


### PR DESCRIPTION
Testing the library with up-to-date versions of go