### PR TITLE
Adds go mod files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Seklfreak/adyen-api-go
+module github.com/zhutik/adyen-api-go
 
 require (
 	github.com/google/go-querystring v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/Seklfreak/adyen-api-go
+
+require (
+	github.com/google/go-querystring v1.0.0
+	github.com/joho/godotenv v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=


### PR DESCRIPTION
Golang 1.11 adds preliminary for Golang Modules.
https://github.com/golang/go/wiki/Modules

Golang Modules allow versioned dependency management. 

This PR adds the files necessary for go mod projects.

After merging the PR, a new version tag should be created, so go mod can use that as the version to import. 