### PR TITLE
notification signature validation

### DIFF
--- a/amount_test.go
+++ b/amount_test.go
@@ -1,6 +1,7 @@
 package adyen
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -55,5 +56,27 @@ func TestNewAmount(t *testing.T) {
 
 			equals(t, c.expected, *a)
 		})
+	}
+}
+
+func TestAmount_UnmarshalJson(t *testing.T) {
+	t.Parallel()
+
+	structJSON := `
+{
+	"currency" : "KWD",
+	"value"    : 87230
+}
+`
+	var amount Amount
+	err := json.Unmarshal([]byte(structJSON), &amount)
+	if err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if amount.Currency != "KWD" {
+		t.Fatalf("expected currency KWD, but got %s in unmarshaled struct %+v", amount.Currency, amount)
+	}
+	if amount.Value != 87230.0 {
+		t.Fatalf("expected value 87230.0, but got %f in unmarshaled struct %+v", amount.Value, amount)
 	}
 }

--- a/notification.go
+++ b/notification.go
@@ -29,6 +29,7 @@ type NotificationRequestItemData struct {
 		ExpiryDate               string `json:"expiryDate,omitempty"`
 		AuthorisedAmountValue    string `json:"authorisedAmountValue,omitempty"`
 		AuthorisedAmountCurrency string `json:"authorisedAmountCurrency,omitempty"`
+		HmacSignature            string `json:"hmacSignature,omitempty"`
 	} `json:"additionalData,omitempty"`
 	Amount              Amount     `json:"amount"`
 	PspReference        string     `json:"pspReference"`

--- a/signature.go
+++ b/signature.go
@@ -117,3 +117,43 @@ func (r *SkipHppRequest) CalculateSignature(adyen *Adyen) error {
 	r.MerchantSig = base64.StdEncoding.EncodeToString(mac.Sum(nil))
 	return nil
 }
+
+// ValidateSignature validate HMAC signature for notification event
+//
+// Link: https://docs.adyen.com/development-resources/notifications/verify-hmac-signatures#verify-using-your-own-solution
+func (n *NotificationRequestItemData) ValidateSignature(adyen *Adyen) (bool, error) {
+	var precondition error
+	providedSig := n.AdditionalData.HmacSignature
+	if len(providedSig) == 0 {
+		precondition = errors.New("no HMAC signature in message")
+	} else if len(adyen.Credentials.Hmac) == 0 {
+		precondition = errors.New("no HMAC key configured; cannot validate signature")
+	}
+	if precondition != nil {
+		return false, precondition
+	}
+
+	valueInJavaFloatToStringStyle := strconv.FormatFloat(float64(n.Amount.Value), 'f', -1, 32)
+	valueString := strings.Join([]string{
+		replaceSpecialChars(n.PspReference),
+		replaceSpecialChars(n.OriginalReference),
+		replaceSpecialChars(n.MerchantAccountCode),
+		replaceSpecialChars(n.MerchantReference),
+		valueInJavaFloatToStringStyle,
+		replaceSpecialChars(n.Amount.Currency),
+		replaceSpecialChars(n.EventCode),
+		strconv.FormatBool(bool(n.Success)),
+	}, ":")
+
+	src, err := hex.DecodeString(adyen.Credentials.Hmac)
+	if err != nil {
+		return false, err
+	}
+
+	mac := hmac.New(sha256.New, src)
+	if _, err = mac.Write([]byte(valueString)); err != nil {
+		return false, err
+	}
+	expectedSig := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+	return expectedSig == providedSig, nil
+}

--- a/signature_test.go
+++ b/signature_test.go
@@ -1,6 +1,7 @@
 package adyen
 
 import (
+	"encoding/json"
 	"net/http"
 	"os"
 	"testing"
@@ -70,5 +71,98 @@ func TestSignatureCalculateSignatureForSkipHppRequest(t *testing.T) {
 
 	if _, err = http.NewRequest(http.MethodGet, url, nil); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestSignatureNotification(t *testing.T) {
+	t.Parallel()
+
+	//ref: https://github.com/Adyen/adyen-ruby-api-library/blob/53d9a03ab09d58927ec34e65d3d2acc1c5dc1ea7/spec/utils/hmac_validator_spec.rb
+	itemDataJSON := `
+{
+	"additionalData": {
+		"authCode": "1234",
+	    "cardSummary": "7777"
+	},
+	"amount": {
+		"currency": "EUR",
+		"value": 1130
+	},
+	"eventCode": "AUTHORISATION",
+	"eventDate": "2020-01-01T10:00:00+05:00",
+	"merchantAccountCode": "TestMerchant",
+	"merchantReference": "TestPayment-1407325143704",
+	"operations": ["CANCEL", "CAPTURE", "REFUND"],
+	"paymentMethod": "visa",
+	"pspReference": "7914073381342284",
+	"reason": "1234:7777:12\/2012",
+	"success": "true"
+}
+`
+
+	validSignature := "coqCmt/IZ4E3CzPvMY8zTjQVL5hYJUiBRg8UU+iCWo0="
+	cases := []struct {
+		name               string
+		signatureInMessage string
+		hmacKey            string
+		exp                bool
+		expErr             bool
+	}{
+		{
+			name:               "no sig",
+			signatureInMessage: "",
+			hmacKey:            "",
+			exp:                false,
+			expErr:             true,
+		},
+		{
+			name:               "sig, no key",
+			signatureInMessage: validSignature,
+			hmacKey:            "",
+			exp:                false,
+			expErr:             true,
+		},
+		{
+			name:               "sig, wrong key",
+			signatureInMessage: validSignature,
+			hmacKey:            "DFB1EB5485895CFA84146406857104ABB4CBCABDC8AAF103A624C8F6A3EAAB00",
+			exp:                false,
+			expErr:             false,
+		},
+		{
+			name:               "sig, correct key",
+			signatureInMessage: validSignature,
+			hmacKey:            "44782DEF547AAA06C910C43932B1EB0C71FC68D9D0C057550C48EC2ACF6BA056",
+			exp:                true,
+			expErr:             false,
+		},
+		{
+			name:               "sig, malformed key",
+			signatureInMessage: validSignature,
+			hmacKey:            "invalid_hmac",
+			exp:                false,
+			expErr:             true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var itemData NotificationRequestItemData
+			err := json.Unmarshal([]byte(itemDataJSON), &itemData)
+			if err != nil {
+				t.Fatalf("unmarshal error: %v", err)
+			}
+			if c.hmacKey != "" {
+				itemData.AdditionalData.HmacSignature = c.signatureInMessage
+			}
+			config := NewWithHMAC(Testing, "username", "fake_password", c.hmacKey)
+			res, err := itemData.ValidateSignature(config)
+			if (err != nil) != c.expErr {
+				t.Fatalf("expected error?: %t, actual error: %v", c.expErr, err)
+			}
+			if res != c.exp {
+				t.Fatalf("expected result: %t, actual result: %t", c.exp, res)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Adyen recommends turning on HMAC signatures for webhook notifications. https://docs.adyen.com/development-resources/notifications/verify-hmac-signatures
This PR builds support for validating a signature in the payload